### PR TITLE
Allow global registering of commands

### DIFF
--- a/awb.php
+++ b/awb.php
@@ -1,5 +1,7 @@
 <?php
 
+$GLOBALS['awbCommands'] = array();
+
 require __DIR__ . '/vendor/autoload.php';
 
 $awbConfig = new Mediawiki\Bot\Config\AppConfig( __DIR__  );
@@ -13,6 +15,8 @@ $awbApp->addCommands( array(
 	new Mediawiki\Bot\Commands\Task\RestoreRevisions( $awbConfig ),
 	new Mediawiki\Bot\Commands\Task\Purge( $awbConfig ),
 ) );
+
+$awbApp->addCommands( $GLOBALS['awbCommands'] );
 
 if( $awbConfig->isEmpty() ) {
 	$awbApp->setDefaultCommand( 'config:setup' );


### PR DESCRIPTION
Not sure this is the best approach. Users of this library can clone this repository and then add their extensions using `composer require my-cool/extension` but there must be a better method perhaps...