### PR TITLE
[wikibase-api] Only set clear parameter in RevisionSaver if entity is empty

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,8 +5,7 @@ end_of_line = lf
 insert_final_newline = true
 
 [*.php]
-indent_style = space
-indent_size = 4
+indent_style = tab
 
 [*.json]
 indent_style = space

--- a/packages/wikibase-api/RELEASENOTES.md
+++ b/packages/wikibase-api/RELEASENOTES.md
@@ -4,6 +4,7 @@
 
 - Installable with 7.3+ (including PHP8)
 - Set `maxlag` parameter when `EditInfo` with maxlag is passed to `Wikibase\Api\WikibaseApi`
+- `RevisionSaver` only sets `clear` parameter if it is given an empty entity
 
 ## Version 2.7 (15 February 2021)
 

--- a/packages/wikibase-api/src/Api/Service/RevisionSaver.php
+++ b/packages/wikibase-api/src/Api/Service/RevisionSaver.php
@@ -76,6 +76,11 @@ class RevisionSaver {
 		if ( $entityId !== null ) {
 			$params['id'] = $entityId->getSerialization();
 
+			// If we are provided an empty entity, then set the clear flag
+			if ( $entity->isEmpty() ){
+				$params['clear'] = true;
+			}
+
 			// Add more detail to the default "Cleared an entity" summary
 			// Note: this is later overridden if a summary is provided in the EditInfo
 			$params['summary'] = 'Edited a ' . $entity->getType();

--- a/packages/wikibase-api/src/Api/Service/RevisionSaver.php
+++ b/packages/wikibase-api/src/Api/Service/RevisionSaver.php
@@ -77,7 +77,7 @@ class RevisionSaver {
 			$params['id'] = $entityId->getSerialization();
 
 			// If we are provided an empty entity, then set the clear flag
-			if ( $entity->isEmpty() ){
+			if ( $entity->isEmpty() ) {
 				$params['clear'] = true;
 			}
 

--- a/packages/wikibase-api/src/Api/Service/RevisionSaver.php
+++ b/packages/wikibase-api/src/Api/Service/RevisionSaver.php
@@ -76,8 +76,6 @@ class RevisionSaver {
 		if ( $entityId !== null ) {
 			$params['id'] = $entityId->getSerialization();
 
-			// Always clear so that removing elements is possible
-			$params['clear'] = 'true';
 			// Add more detail to the default "Cleared an entity" summary
 			// Note: this is later overridden if a summary is provided in the EditInfo
 			$params['summary'] = 'Edited a ' . $entity->getType();


### PR DESCRIPTION
See https://www.wikidata.org/w/index.php?title=Q4115189&diff=1103741549&oldid=1103729560
this was done with the clear parameter not set.

This was taken from https://github.com/addwiki/wikibase-api/pull/57
