### PR TITLE
Fix a handful of typos in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # addwiki - monorepo
 
-Addwiki is a collection of PHP libraries, packages and applications created for interatcting wit MediaWiki, Wikibase, Wikimedia and more.
+Addwiki is a collection of PHP libraries, packages and applications created for interacting with MediaWiki, Wikibase, Wikimedia and more.
 
 To dive in take a look at the [docs site](https://addwiki.github.io/).
 
@@ -9,7 +9,7 @@ If you want to submit code patches to any of the repositories, then this is the 
 ## Packages
 
 All packages exist in the `/packages` directory.
-Every package also exists in it's own read only git repository, can be used separately and is installable via composer.
+Every package also exists in its own read only git repository, can be used separately and is installable via composer.
 
 **Most popular:**
 

--- a/docs/v2/mediawiki-api-base/index.md
+++ b/docs/v2/mediawiki-api-base/index.md
@@ -1,6 +1,6 @@
 # mediawiki-api-base
 
-addwiki/mediawiki-api-base is a PHP HTTP client wrapped around guzzle that makes it easy to interest with a MediaWiki installation.
+addwiki/mediawiki-api-base is a PHP HTTP client wrapped around guzzle that makes it easy to interact with a MediaWiki installation.
 
 1. Uses PSR-3 interfaces for logging
 2. Handles Mediawiki login, sessions, cookies and tokens

--- a/docs/v3/mediawiki-api-base/index.md
+++ b/docs/v3/mediawiki-api-base/index.md
@@ -1,6 +1,6 @@
 # mediawiki-api-base
 
-addwiki/mediawiki-api-base is a PHP HTTP client wrapped around guzzle that makes it easy to interest with a MediaWiki installation.
+addwiki/mediawiki-api-base is a PHP HTTP client wrapped around guzzle that makes it easy to interact with a MediaWiki installation.
 
 1. Uses PSR-3 interfaces for logging
 2. Handles Mediawiki login, sessions, cookies and tokens

--- a/packages/mediawiki-api/README.md
+++ b/packages/mediawiki-api/README.md
@@ -60,7 +60,7 @@ To run the integration tests, you need to have a running MediaWiki instance. The
 
 to the `LocalSettings.php` of your MediaWiki.
 
-By default, the tests will use the URL `http://localhost/w/api.php` as the API endpoint. If you have a different URL (e.g. `http://localhost:8080/w/api.php`), you need to configure the URL as an environemnt variable before running the tests. Example:
+By default, the tests will use the URL `http://localhost/w/api.php` as the API endpoint. If you have a different URL (e.g. `http://localhost:8080/w/api.php`), you need to configure the URL as an environment variable before running the tests. Example:
 
     export MEDIAWIKI_API_URL='http://localhost:8080/w/api.php'
 

--- a/packages/wikibase-api/README.md
+++ b/packages/wikibase-api/README.md
@@ -68,7 +68,7 @@ $itemId = $resultingItem->getId()
 
 #### Set a label
 
-Set an english label on the item Q87 assuming it exists, using a custom summary.
+Set an English label on the item Q87 assuming it exists, using a custom summary.
 
 ```php
 $getter = $wbFactory->newRevisionGetter();


### PR DESCRIPTION
Noticed a few in README.md, and scanned through the entire tree. Making no claim to be complete. :)