### PR TITLE
Normalize case of HTTP method name

### DIFF
--- a/packages/mediawiki-api-base/src/Client/Request/MethodTrait.php
+++ b/packages/mediawiki-api-base/src/Client/Request/MethodTrait.php
@@ -11,7 +11,7 @@ trait MethodTrait {
 	}
 
 	public function setMethod( string $method ): self {
-		$this->method = $method;
+		$this->method = strtoupper( $method );
 		return $this;
 	}
 

--- a/packages/mediawiki-api-base/tests/unit/Client/Action/Request/FluentRequestTest.php
+++ b/packages/mediawiki-api-base/tests/unit/Client/Action/Request/FluentRequestTest.php
@@ -62,4 +62,17 @@ class FluentRequestTest extends TestCase {
 		$this->assertEquals( [ 'action' => 'fooAction' ], $request->getParams() );
 	}
 
+	public function testGetParameterEncoding(): void {
+		$request = ActionRequest::factory();
+
+		$request->setMethod( 'get' );
+		$this->assertSame( 'query', $request->getParameterEncoding() );
+
+		$request->setMethod( 'GET' );
+		$this->assertSame( 'query', $request->getParameterEncoding() );
+
+		$request->setMethod( 'post' );
+		$this->assertSame( 'form_params', $request->getParameterEncoding() );
+	}
+
 }


### PR DESCRIPTION
Because ParametersTrait::getParameterEncoding() checks against uppercase GET, it seems to make sense to uppercase the input when it's set. This does that and adds some slight tests for it.

Refs #166