### PR TITLE
Update composer releases that support PHP >8.1.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,11 +27,11 @@
     "require": {
         "benestar/asparagus": "~0.4",
         "composer/semver": "^3.2",
-        "data-values/common": "~0.4.0",
-        "data-values/data-values": "~2.0",
+        "data-values/common": "~1.0",
+        "data-values/data-values": "^3.1.0",
         "data-values/geo": "~4.0",
         "data-values/interfaces": "~0.2.0||~0.1.5",
-        "data-values/number": "~0.10.0",
+        "data-values/number": "~0.12",
         "data-values/serialization": "~1.0",
         "data-values/time": "~1.0",
         "ext-curl": "*",
@@ -44,9 +44,9 @@
         "serialization/serialization": "~3.2||~4.0",
         "symfony/console": "~5.0||~6.0",
         "symfony/yaml": "~4.0||~5.0",
-        "wikibase/data-model": "~9.2||~8.0",
+        "wikibase/data-model": "dev-master#cbbdfcb13e026357f7d441b9c901f06263304e46",
         "wikibase/data-model-serialization": "~2.0",
-        "wikibase/data-model-services": "~4.0"
+        "wikibase/data-model-services": "^5.4.0"
     },
     "suggest": {
         "ext-dom": "Needed if you want to discover APIs using only page URLs",

--- a/packages/wikibase-datamodel/composer.json
+++ b/packages/wikibase-datamodel/composer.json
@@ -33,7 +33,7 @@
     "require": {
         "php": ">=8.1",
         "addwiki/mediawiki-datamodel": "^3.1",
-        "wikibase/data-model": "~9.2||~8.0",
+        "wikibase/data-model": "dev-master#cbbdfcb13e026357f7d441b9c901f06263304e46",
         "serialization/serialization": "~3.2||~4.0"
     },
     "require-dev": {


### PR DESCRIPTION
```addwiki on  composer-fixes is 📦 0.0.0 via 🐘 v8.1.29 
➜ ./vendor/bin/phpunit packages/wikibase-datamodel/tests 
PHPUnit 9.6.20 by Sebastian Bergmann and contributors.

....                                                                4 / 4 (100%)

Time: 00:00.007, Memory: 6.00 MB

OK (4 tests, 6 assertions)
```