### PR TITLE
Update Wikibase datamodel MediaInfo and related classes.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,11 +27,11 @@
     "require": {
         "benestar/asparagus": "~0.4",
         "composer/semver": "^3.2",
-        "data-values/common": "~0.4.0",
-        "data-values/data-values": "~2.0",
+        "data-values/common": "~1.0",
+        "data-values/data-values": "^3.1.0",
         "data-values/geo": "~4.0",
         "data-values/interfaces": "~0.2.0||~0.1.5",
-        "data-values/number": "~0.10.0",
+        "data-values/number": "~0.12",
         "data-values/serialization": "~1.0",
         "data-values/time": "~1.0",
         "ext-curl": "*",
@@ -44,9 +44,9 @@
         "serialization/serialization": "~3.2||~4.0",
         "symfony/console": "~5.0||~6.0",
         "symfony/yaml": "~4.0||~5.0",
-        "wikibase/data-model": "~9.2||~8.0",
-        "wikibase/data-model-serialization": "~2.0",
-        "wikibase/data-model-services": "~4.0"
+        "wikibase/data-model": "dev-master#cbbdfcb13e026357f7d441b9c901f06263304e46",
+        "wikibase/data-model-serialization": "dev-master#e3aeaa4a94a587dfcaa45c9555ac0bd46498f227",
+        "wikibase/data-model-services": "^5.4.0"
     },
     "suggest": {
         "ext-dom": "Needed if you want to discover APIs using only page URLs",

--- a/packages/wikibase-datamodel/composer.json
+++ b/packages/wikibase-datamodel/composer.json
@@ -33,7 +33,7 @@
     "require": {
         "php": ">=8.1",
         "addwiki/mediawiki-datamodel": "^3.1",
-        "wikibase/data-model": "~9.2||~8.0",
+        "wikibase/data-model": "dev-master#cbbdfcb13e026357f7d441b9c901f06263304e46",
         "serialization/serialization": "~3.2||~4.0"
     },
     "require-dev": {

--- a/packages/wikibase-datamodel/lib/wikibase/media-info/src/DataModel/MediaInfo.php
+++ b/packages/wikibase-datamodel/lib/wikibase/media-info/src/DataModel/MediaInfo.php
@@ -71,7 +71,7 @@ class MediaInfo
 	}
 
 	/**
-	 * @return EntityId|null
+	 * @return MediaInfoId|null
 	 */
 	public function getId() {
 		return $this->id;

--- a/packages/wikibase-datamodel/lib/wikibase/media-info/src/DataModel/MediaInfoId.php
+++ b/packages/wikibase-datamodel/lib/wikibase/media-info/src/DataModel/MediaInfoId.php
@@ -81,11 +81,11 @@ class MediaInfoId extends SerializableEntityId implements Int32EntityId {
 	/**
 	 * @see Serializable::unserialize
 	 *
-	 * @param array $value
+	 * @param array $serialized
 	 */
-	public function __unserialize( array $value ): void {
-		$this->__construct( $value['serialization'] ?? '' );
-		if ( $this->serialization !== $value['serialization'] ) {
+	public function __unserialize( array $serialized ): void {
+		$this->__construct( $serialized['serialization'] ?? '' );
+		if ( $this->serialization !== $serialized['serialization'] ) {
 			throw new InvalidArgumentException( '$value contained invalid serialization' );
 		}
 	}

--- a/packages/wikibase-datamodel/lib/wikibase/media-info/src/DataModel/MediaInfoId.php
+++ b/packages/wikibase-datamodel/lib/wikibase/media-info/src/DataModel/MediaInfoId.php
@@ -5,6 +5,7 @@ namespace Wikibase\MediaInfo\DataModel;
 use InvalidArgumentException;
 use Wikibase\DataModel\Entity\EntityId;
 use Wikibase\DataModel\Entity\Int32EntityId;
+use Wikibase\DataModel\Entity\SerializableEntityId;
 
 /**
  * Identifier for media info entities, containing a numeric id prefixed by 'M'.
@@ -15,7 +16,7 @@ use Wikibase\DataModel\Entity\Int32EntityId;
  * @author Bene* < benestar.wikimedia@gmail.com >
  * @author Thiemo Kreuz
  */
-class MediaInfoId extends EntityId implements Int32EntityId {
+class MediaInfoId extends SerializableEntityId implements Int32EntityId {
 
 	public const PATTERN = '/^M[1-9]\d{0,9}\z/i';
 
@@ -25,14 +26,15 @@ class MediaInfoId extends EntityId implements Int32EntityId {
 	 * @throws InvalidArgumentException
 	 */
 	public function __construct( $idSerialization ) {
-		$parts = self::splitSerialization( $idSerialization );
-		$this->assertValidIdFormat( $parts[2] );
-		parent::__construct( self::joinSerialization(
-			[ $parts[0], $parts[1], strtoupper( $parts[2] ) ]
-		) );
+		$this->assertValidIdFormat( $idSerialization );
+		parent::__construct( strtoupper( $idSerialization ) );
 	}
 
-	private function assertValidIdFormat( $idSerialization ) {
+	/**
+	 * @param $idSerialization
+	 * @return void
+	 */
+	private function assertValidIdFormat( $idSerialization ): void {
 		if ( !is_string( $idSerialization ) ) {
 			throw new InvalidArgumentException( '$idSerialization must be a string' );
 		}
@@ -54,9 +56,8 @@ class MediaInfoId extends EntityId implements Int32EntityId {
 	 *
 	 * @return int Guaranteed to be a unique integer in the range [1..2147483647].
 	 */
-	public function getNumericId() {
-		$serializationParts = self::splitSerialization( $this->serialization );
-		return (int)substr( $serializationParts[2], 1 );
+	public function getNumericId(): int {
+		return (int)substr( $this->serialization, 1 );
 	}
 
 	/**
@@ -64,29 +65,29 @@ class MediaInfoId extends EntityId implements Int32EntityId {
 	 *
 	 * @return string
 	 */
-	public function getEntityType() {
+	public function getEntityType(): string {
 		return 'mediainfo';
 	}
 
 	/**
 	 * @see Serializable::serialize
 	 *
-	 * @return string
+	 * @return array
 	 */
-	public function serialize() {
-		return $this->serialization;
+	public function __serialize(): array {
+		return [ 'serialization' => $this->serialization ];
 	}
 
 	/**
 	 * @see Serializable::unserialize
 	 *
-	 * @param string $value
+	 * @param array $value
 	 */
-	public function unserialize( $value ) {
-		$this->serialization = $value;
-		list( $this->repositoryName, $this->localPart ) = self::extractRepositoryNameAndLocalPart(
-			$value
-		);
+	public function __unserialize( array $value ): void {
+		$this->__construct( $value['serialization'] ?? '' );
+		if ( $this->serialization !== $value['serialization'] ) {
+			throw new InvalidArgumentException( '$value contained invalid serialization' );
+		}
 	}
 
 }

--- a/packages/wikibase-datamodel/src/DataModelFactory.php
+++ b/packages/wikibase-datamodel/src/DataModelFactory.php
@@ -6,11 +6,12 @@ use Deserializers\Deserializer;
 use Deserializers\DispatchingDeserializer;
 use Serializers\DispatchingSerializer;
 use Serializers\Serializer;
-use Wikibase\DataModel\DeserializerFactory;
+use Wikibase\DataModel\Deserializers\DeserializerFactory;
 use Wikibase\DataModel\Entity\DispatchingEntityIdParser;
 use Wikibase\DataModel\Entity\ItemId;
-use Wikibase\DataModel\Entity\PropertyId;
-use Wikibase\DataModel\SerializerFactory;
+use Wikibase\DataModel\Entity\NumericPropertyId;
+use Wikibase\DataModel\Serializers\SerializerFactory;
+use Wikibase\DataModel\Services\Lookup\InMemoryDataTypeLookup;
 use Wikibase\MediaInfo\DataModel\MediaInfoId;
 use Wikibase\MediaInfo\DataModel\Serialization\MediaInfoDeserializer;
 use Wikibase\MediaInfo\DataModel\Serialization\MediaInfoSerializer;
@@ -44,7 +45,10 @@ class DataModelFactory {
 	private function newDefaultDataModelDeserializerFactory(): DeserializerFactory {
 		return new DeserializerFactory(
 			$this->dataValueDeserializer,
-			$this->newEntityIdParser()
+			$this->newEntityIdParser(),
+			new InMemoryDataTypeLookup(),
+			[],
+			[]
 		);
 	}
 
@@ -54,8 +58,8 @@ class DataModelFactory {
 			ItemId::PATTERN => static function ( $serialization ) {
 				return new ItemId( $serialization );
 			},
-			PropertyId::PATTERN => static function ( $serialization ) {
-				return new PropertyId( $serialization );
+			NumericPropertyId::PATTERN => static function ( $serialization ) {
+				return new NumericPropertyId( $serialization );
 			},
 			// The MediaInfo extension
 			MediaInfoId::PATTERN => static function ( $serialization ) {

--- a/packages/wikibase-datamodel/src/DataModelFactory.php
+++ b/packages/wikibase-datamodel/src/DataModelFactory.php
@@ -2,6 +2,7 @@
 
 namespace Addwiki\Wikibase\DataModel;
 
+use DataValues\Deserializers\DataValueDeserializer;
 use Deserializers\Deserializer;
 use Deserializers\DispatchingDeserializer;
 use Serializers\DispatchingSerializer;
@@ -17,34 +18,68 @@ use Wikibase\MediaInfo\DataModel\Serialization\MediaInfoDeserializer;
 use Wikibase\MediaInfo\DataModel\Serialization\MediaInfoSerializer;
 
 /**
+ * Factory class for creating various data model serializers and deserializers.
+ *
  * @access public
  */
 class DataModelFactory {
 
+	/**
+	 * @var Deserializer Deserializer for data values.
+	 */
 	private Deserializer $dataValueDeserializer;
 
+	/**
+	 * @var Serializer Serializer for data values.
+	 */
 	private Serializer $dataValueSerializer;
 
+	/**
+	 * Constructor for DataModelFactory.
+	 *
+	 * @param Deserializer $dvDeserializer Deserializer for data values.
+	 * @param Serializer $dvSerializer Serializer for data values.
+	 */
 	public function __construct( Deserializer $dvDeserializer, Serializer $dvSerializer ) {
 		$this->dataValueDeserializer = $dvDeserializer;
 		$this->dataValueSerializer = $dvSerializer;
 	}
 
+	/**
+	 * Get the data value deserializer.
+	 *
+	 * @return Deserializer
+	 */
 	public function getDataValueDeserializer(): Deserializer {
 		return $this->dataValueDeserializer;
 	}
 
+	/**
+	 * Get the data value serializer.
+	 *
+	 * @return Serializer
+	 */
 	public function getDataValueSerializer(): Serializer {
 		return $this->dataValueSerializer;
 	}
 
+	/**
+	 * Create a new default data model serializer factory.
+	 *
+	 * @return SerializerFactory
+	 */
 	private function newDefaultDataModelSerializerFactory(): SerializerFactory {
 		return new SerializerFactory( $this->dataValueSerializer );
 	}
 
+	/**
+	 * Create a new default data model deserializer factory.
+	 *
+	 * @return DeserializerFactory
+	 */
 	private function newDefaultDataModelDeserializerFactory(): DeserializerFactory {
 		return new DeserializerFactory(
-			$this->dataValueDeserializer,
+			new DataValueDeserializer(),
 			$this->newEntityIdParser(),
 			new InMemoryDataTypeLookup(),
 			[],
@@ -52,7 +87,12 @@ class DataModelFactory {
 		);
 	}
 
-	public function newEntityIdParser() {
+	/**
+	 * Create a new entity ID parser.
+	 *
+	 * @return DispatchingEntityIdParser
+	 */
+	public function newEntityIdParser(): DispatchingEntityIdParser {
 		$builders = [
 			// Defaults in all Wikibases
 			ItemId::PATTERN => static function ( $serialization ) {
@@ -69,6 +109,11 @@ class DataModelFactory {
 		return new DispatchingEntityIdParser( $builders );
 	}
 
+	/**
+	 * Create a new entity deserializer.
+	 *
+	 * @return Deserializer
+	 */
 	public function newEntityDeserializer(): Deserializer {
 		$datamodelDeserializerFactory = $this->newDefaultDataModelDeserializerFactory();
 		return new DispatchingDeserializer( [
@@ -83,6 +128,11 @@ class DataModelFactory {
 		] );
 	}
 
+	/**
+	 * Create a new entity serializer.
+	 *
+	 * @return Serializer
+	 */
 	public function newEntitySerializer(): Serializer {
 		$datamodelSerializerFactory = $this->newDefaultDataModelSerializerFactory();
 		return new DispatchingSerializer( [
@@ -96,14 +146,29 @@ class DataModelFactory {
 		] );
 	}
 
+	/**
+	 * Create a new statement deserializer.
+	 *
+	 * @return Deserializer
+	 */
 	public function newStatementDeserializer(): Deserializer {
 		return $this->newDefaultDataModelDeserializerFactory()->newStatementDeserializer();
 	}
 
+	/**
+	 * Create a new statement serializer.
+	 *
+	 * @return Serializer
+	 */
 	public function newStatementSerializer(): Serializer {
 		return $this->newDefaultDataModelSerializerFactory()->newStatementSerializer();
 	}
 
+	/**
+	 * Create a new reference serializer.
+	 *
+	 * @return Serializer
+	 */
 	public function newReferenceSerializer(): Serializer {
 		return $this->newDefaultDataModelSerializerFactory()->newReferenceSerializer();
 	}


### PR DESCRIPTION
### Purpose:
- Improve type safety and consistency in MediaInfo-related classes
- Update serialization methods to use newer PHP serialization interfaces
- Align with changes in the Wikibase DataModel, particularly regarding PropertyId
- Update namespace for (De)serializerFactory to reflect changes in the Wikibase codebase (reference to https://github.com/wikimedia/mediawiki-extensions-WikibaseMediaInfo/commits/master/?since=2021-09-21&until=2021-09-22)

### Changes:

1. lib/wikibase/media-info/src/DataModel/MediaInfo.php:
   - Updated return type hint for `getId()` method from `EntityId|null` to `MediaInfoId|null`

2. lib/wikibase/media-info/src/DataModel/MediaInfoId.php:
   - Changed parent class from `EntityId` to `SerializableEntityId`
   - Simplified constructor to use `strtoupper()` directly on `$idSerialization`
   - Updated `getNumericId()` method to use `$this->serialization` directly
   - Changed `serialize()` method to `__serialize()` returning an array
   - Changed `unserialize()` method to `__unserialize()` accepting an array

3. src/DataModelFactory.php:
   - Updated import statements
   - Changed `PropertyId` to `NumericPropertyId`
   - Added `InMemoryDataTypeLookup` and additional parameters to `DeserializerFactory` constructor
   - Updated entity ID parser to use `NumericPropertyId` instead of `PropertyId`
   - Changed DeserializerFactory namespace from `Wikibase\DataModel\DeserializerFactory` to `Wikibase\DataModel\Deserializers\DeserializerFactory`


### PHPUnit
```
addwiki on  wikibase-datamodel-namespace-return-type-fixes is 📦 0.0.0 via 🐘 v8.1.29 
➜ ./vendor/bin/phpunit packages/wikibase-datamodel/tests                       
PHPUnit 9.6.20 by Sebastian Bergmann and contributors.

....                                                                4 / 4 (100%)

Time: 00:00.008, Memory: 6.00 MB

OK (4 tests, 6 assertions)
```