### PR TITLE
Update mediawiki/oauthclient to ^2.1

### DIFF
--- a/.github/workflows/composer_test.yaml
+++ b/.github/workflows/composer_test.yaml
@@ -38,9 +38,9 @@ jobs:
                 with:
                     composer-options: "--ignore-platform-req php"
 
-            -   name: Run CI docker-compose if present
-                run: '(test -f docker-compose-ci.yml && docker-compose --file docker-compose-ci.yml up -d) || echo No docker-compose-ci.yml, skipping step'
-            -   name: Wait for docker-compose to be ready (if needed)
+            -   name: Run CI docker compose if present
+                run: '(test -f docker-compose-ci.yml && docker compose --file docker-compose-ci.yml up -d) || echo No docker-compose-ci.yml, skipping step'
+            -   name: Wait for docker compose to be ready (if needed)
                 run: '(test -f build/docker-compose-ci-wait.sh && build/docker-compose-ci-wait.sh) || echo No docker-compose-ci-wait.sh, not waiting'
 
             -

--- a/.github/workflows/split_composer_test.yaml
+++ b/.github/workflows/split_composer_test.yaml
@@ -48,10 +48,10 @@ jobs:
 
             -   run: composer update --no-progress --ansi --working-dir packages/${{ matrix.package }}
 
-            -   name: Run CI docker-compose if present
+            -   name: Run CI docker compose if present
                 if: ${{ matrix.package == 'mediawiki-api-base' || matrix.package == 'mediawiki-api' || matrix.package == 'wikibase-api' }}
-                run: 'docker-compose --file docker-compose-ci.yml up -d'
-            -   name: Wait for docker-compose to be ready (if needed)
+                run: 'docker compose --file docker-compose-ci.yml up -d'
+            -   name: Wait for docker compose to be ready (if needed)
                 if: ${{ matrix.package == 'mediawiki-api-base' || matrix.package == 'mediawiki-api' || matrix.package == 'wikibase-api' }}
                 run: 'build/docker-compose-ci-wait.sh'
 

--- a/README.md
+++ b/README.md
@@ -87,12 +87,12 @@ Run phpunit unit tests on a single package:
 vendor/bin/phpunit packages/mediawiki-api-base/tests/unit
 ```
 
-Integration tests are facilitated by `docker-composer-ci.yml` files which are currently kept in sync manually.
+Integration tests are facilitated by `docker-compose-ci.yml` files which are currently kept in sync manually.
 The setup in the monorepo should work for all packages.
 Run it before running integration tests.
 
 ```sh
-docker-compose -f docker-compose-ci.yml up -d --build
+docker compose -f docker-compose-ci.yml up -d --build
 ```
 
 Wait for the wiki to be accessible, then run the tests:

--- a/build/docker-compose-ci-wait.sh
+++ b/build/docker-compose-ci-wait.sh
@@ -5,7 +5,7 @@ repo_path=$(dirname $(dirname $(realpath $0)))
 # Wait for apache to actually be running
 for i in {1..30}
 do
-    docker-compose --project-directory $repo_path --file $repo_path/docker-compose-ci.yml logs mediawiki | grep "+ apache2-foreground" | wc -l | grep 1
+    docker compose --project-directory $repo_path --file $repo_path/docker-compose-ci.yml logs mediawiki | grep "+ apache2-foreground" | wc -l | grep 1
     if [ $? -eq 0 ]
     then
         sleep 1

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "guzzlehttp/guzzle": "~6.3||~7.0",
         "guzzlehttp/promises": "~1.0",
         "linclark/microdata-php": "~2.0",
-        "mediawiki/oauthclient": "dev-master#ac9f5f796e248682a9e5441bb85a9ec963a50617",
+        "mediawiki/oauthclient": "^2.1",
         "php": ">=8.1",
         "psr/log": "~3.0",
         "serialization/serialization": "~3.2||~4.0",

--- a/packages/mediawiki-api-base/README.md
+++ b/packages/mediawiki-api-base/README.md
@@ -29,7 +29,7 @@ $api->postRequest( $purgeRequest );
 Run the MediaWiki test site:
 
 ```sh
-docker-compose -f docker-compose-ci.yml up -d
+docker compose -f docker-compose-ci.yml up -d
 ```
 
 Run the tests:
@@ -41,5 +41,5 @@ composer phpunit-integration
 Destroy the site that was used for testing:
 
 ```sh
-docker-compose -f docker-compose-ci.yml down --volumes
+docker compose -f docker-compose-ci.yml down --volumes
 ```

--- a/packages/mediawiki-api-base/composer.json
+++ b/packages/mediawiki-api-base/composer.json
@@ -27,7 +27,7 @@
         "guzzlehttp/guzzle": "~6.3||~7.0",
         "guzzlehttp/promises": "~1.0",
         "psr/log": "~3.0",
-        "mediawiki/oauthclient": "dev-master#ac9f5f796e248682a9e5441bb85a9ec963a50617"
+        "mediawiki/oauthclient": "^2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~9",


### PR DESCRIPTION
The ac9f5f796e248682a9e5441bb85a9ec963a50617 patch is now part of 2.1 and 2.2.

Also update `docker-compose` to `docker compose` in order to get the tests passing.