### PR TITLE
Cleanup and refine remnants of the split monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ Run phpunit tests on a single internal package:
 vendor/bin/phpunit packages/mediawiki-api-base/tests/unit
 ```
 
-Integration tests are facilitated by `docker-compose-ci.yml` files which are currently kept in sync manually.
-The setup in the monorepo should work for all packages.
+Integration tests are facilitated by the `docker-compose-ci.yml` file.
 Run it before running integration tests.
 
 ```sh

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -10,6 +10,7 @@ This repository now ships as a single Composer package: `addwiki/addwiki`.
 - Removed split-package Composer manifests and split-release workflows.
 - Unified test and validation workflows at repository root.
 - Consolidated packaging metadata and housekeeping files to the root.
+- Refined internal package documentation and updated references to the unified package.
 
 ## Historical notes
 

--- a/examples/check.php
+++ b/examples/check.php
@@ -23,7 +23,7 @@ php check.php https://www.mediawiki.org/
 - Prints `NOT_OK` and exits with code `1` otherwise.
 
 ## Detection strategy
-The script uses `MediaWiki::newFromPage(...)` from `addwiki/mediawiki-api-base`,
+The script uses `MediaWiki::newFromPage(...)` from `addwiki/addwiki`,
 then calls `action()->getVersion()`. If that succeeds, it prints `OK`.
 */
 

--- a/packages/mediawiki-api-base/README.md
+++ b/packages/mediawiki-api-base/README.md
@@ -30,22 +30,3 @@ $purgeRequest = FluentRequest::factory()->setAction( 'purge' )->setParam( 'title
 $api->postRequest( $purgeRequest );
 ```
 
-## Integration tests
-
-Run the MediaWiki test site:
-
-```sh
-docker compose -f docker-compose-ci.yml up -d
-```
-
-Run the tests:
-
-```sh
-composer phpunit-integration
-```
-
-Destroy the site that was used for testing:
-
-```sh
-docker compose -f docker-compose-ci.yml down --volumes
-```

--- a/packages/mediawiki-api-base/src/Guzzle/ClientFactory.php
+++ b/packages/mediawiki-api-base/src/Guzzle/ClientFactory.php
@@ -74,7 +74,7 @@ class ClientFactory implements LoggerAwareInterface {
 	private function setDefaultHandlerIfNotInConfigAlready(): void {
 		if ( !array_key_exists( 'handler', $this->config ) ) {
 			if ( !extension_loaded( 'curl' ) ) {
-				throw new RuntimeException( 'PHP extension ext-curl is required by addwiki/mediawiki-api-base for HTTP requests.' );
+				throw new RuntimeException( 'PHP extension ext-curl is required by addwiki/addwiki for HTTP requests.' );
 			}
 
 			$this->config['handler'] = HandlerStack::create( new CurlHandler() );

--- a/packages/mediawiki-api/README.md
+++ b/packages/mediawiki-api/README.md
@@ -6,7 +6,9 @@
 
 Install the unified toolkit package:
 
-	composer require addwiki/addwiki
+```sh
+composer require addwiki/addwiki
+```
 
 This module lives in `packages/mediawiki-api` and is autoloaded via the root package.
 
@@ -52,16 +54,3 @@ $services->newRevisionSaver()->save( $revision );
 $pages = $services->newPageListGetter()->getPageListFromCategoryName( 'Category:Cat name' );
 ```
 
-## Running the integration tests
-
-To run the integration tests, you need to have a running MediaWiki instance. The tests will create pages and categories without using a user account so it's best if you use a test instance. Furthermore you need to turn off rate limiting by adding the line
-
-   $wgGroupPermissions['*']['noratelimit'] = true;
-
-to the `LocalSettings.php` of your MediaWiki.
-
-By default, the tests will use the URL `http://localhost/w/api.php` as the API endpoint. If you have a different URL (e.g. `http://localhost:8080/w/api.php`), you need to configure the URL as an environment variable before running the tests. Example:
-
-    export MEDIAWIKI_API_URL='http://localhost:8080/w/api.php'
-
-**Warning:** Running the integration tests can take a long time to complete.

--- a/packages/mediawiki-datamodel/README.md
+++ b/packages/mediawiki-datamodel/README.md
@@ -6,6 +6,8 @@
 
 Install the unified toolkit package:
 
-    composer require addwiki/addwiki
+```sh
+composer require addwiki/addwiki
+```
 
 This module lives in `packages/mediawiki-datamodel` and is autoloaded via the root package.

--- a/packages/mediawiki-sitematrix-api/README.md
+++ b/packages/mediawiki-sitematrix-api/README.md
@@ -6,7 +6,9 @@
 
 Install the unified toolkit package:
 
-    composer require addwiki/addwiki
+```sh
+composer require addwiki/addwiki
+```
 
 This module lives in `packages/mediawiki-sitematrix-api` and is autoloaded via the root package.
 

--- a/packages/wikibase-api/README.md
+++ b/packages/wikibase-api/README.md
@@ -8,7 +8,9 @@ Issue tracker: https://github.com/addwiki/addwiki/issues
 
 Install the unified toolkit package:
 
-    composer require addwiki/addwiki
+```sh
+composer require addwiki/addwiki
+```
 
 This module lives in `packages/wikibase-api` and is autoloaded via the root package.
 

--- a/packages/wikibase-datamodel/README.md
+++ b/packages/wikibase-datamodel/README.md
@@ -12,7 +12,9 @@ There are probably not many use cases where you would want to use this module di
 
 Install the unified toolkit package:
 
-    composer require addwiki/addwiki
+```sh
+composer require addwiki/addwiki
+```
 
 This module lives in `packages/wikibase-datamodel` and is autoloaded via the root package.
 
@@ -24,8 +26,8 @@ require_once( __DIR__ . '/vendor/autoload.php' );
 
 ## External Libraries
 
-Some code, such as `MediaInfo` realted code is pulled in from MediaWiki extensions and can be found in the `/lib` directory.
-This is because this code is not availible as a library, but there is little point in rewriting it...
+Some code, such as `MediaInfo` related code is pulled in from MediaWiki extensions and can be found in the `/lib` directory.
+This is because this code is not available as a library, but there is little point in rewriting it...
 
 This code can be updated using the `sync-copied-files` composer command.
 

--- a/packages/wikibase-query/README.md
+++ b/packages/wikibase-query/README.md
@@ -8,7 +8,9 @@ Issue tracker: https://github.com/addwiki/addwiki/issues
 
 Install the unified toolkit package:
 
-    composer require addwiki/addwiki
+```sh
+composer require addwiki/addwiki
+```
 
 This module lives in `packages/wikibase-query` and is autoloaded via the root package.
 

--- a/packages/wikimedia/README.md
+++ b/packages/wikimedia/README.md
@@ -6,6 +6,8 @@ Issue tracker: https://github.com/addwiki/addwiki/issues
 
 Install the unified toolkit package:
 
-	composer require addwiki/addwiki
+```sh
+composer require addwiki/addwiki
+```
 
 This module lives in `packages/wikimedia` and is autoloaded via the root package.


### PR DESCRIPTION
This PR cleans up the remaining references to the split monorepo structure, unifying the documentation and internal references to point to the single `addwiki/addwiki` package.

Key changes:
- Replaced `addwiki/mediawiki-api-base` and other internal package names with `addwiki/addwiki` in comments and exception messages.
- Standardized `README.md` files across all packages in the `packages/` directory, ensuring they all point to the unified installation method and removing redundant setup instructions for integration tests that are now centralized.
- Updated the root `README.md` and `RELEASENOTES.md` to accurately describe the current repository state and the transition process.
- Fixed minor typos in `packages/wikibase-datamodel/README.md`.

---
*PR created automatically by Jules for task [3907799567488488858](https://jules.google.com/task/3907799567488488858) started by @addshore*