### PR TITLE
Allow guzzlehttp/promises 2.x to resolve Guzzle 7.12+ conflicts

### DIFF
--- a/.github/workflows/composer_test.yaml
+++ b/.github/workflows/composer_test.yaml
@@ -43,7 +43,12 @@ jobs:
 
     examples:
         runs-on: ubuntu-latest
-        name: Examples smoke test (PHP 8.5)
+        name: Examples smoke test (PHP 8.5, Guzzle ${{ matrix.guzzle }})
+
+        strategy:
+            fail-fast: false
+            matrix:
+                guzzle: ["^6.5.8", "^7.0"]
 
         steps:
             -   uses: actions/checkout@v4
@@ -57,7 +62,9 @@ jobs:
                     coverage: none
 
             -   name: Install example dependencies
-                run: composer --working-dir=examples install --no-interaction --prefer-dist --ignore-platform-req php
+                run: |
+                    composer --working-dir=examples require "guzzlehttp/guzzle:${{ matrix.guzzle }}" --no-interaction --no-install
+                    composer --working-dir=examples update --no-interaction --prefer-dist --ignore-platform-req php
 
             -   name: Run examples
                 run: composer --working-dir=examples test

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "data-values/time": "~1.0",
         "ext-curl": "*",
         "guzzlehttp/guzzle": "~6.3||~7.0",
-        "guzzlehttp/promises": "~1.0||^2.5",
+        "guzzlehttp/promises": "^1.1 || ^2.0",
         "linclark/microdata-php": "~2.0",
         "mediawiki/oauthclient": "^2.1",
         "php": ">=8.1",

--- a/examples/composer.json
+++ b/examples/composer.json
@@ -11,7 +11,8 @@
     ],
     "require": {
         "php": ">=8.1",
-        "addwiki/addwiki": "dev-main"
+        "addwiki/addwiki": "dev-main",
+        "guzzlehttp/guzzle": "^7.0"
     },
     "scripts": {
         "test": [


### PR DESCRIPTION
I have updated the `guzzlehttp/promises` dependency constraint in `composer.json` to `^1.1 || ^2.0`. This change allows the project to use both the older 1.x and the newer 2.x versions of the promises library, which is necessary for compatibility with recent versions of Guzzle 7. I have verified this change by running all unit tests with both version 1.x and version 2.x of `guzzlehttp/promises` and they all passed.

---
*PR created automatically by Jules for task [13319536595289652543](https://jules.google.com/task/13319536595289652543) started by @addshore*