### PR TITLE
Add unit tests for MediaWikiApi multipart functionality

### DIFF
--- a/packages/mediawiki-api-base/tests/unit/Client/Action/ActionApiTest.php
+++ b/packages/mediawiki-api-base/tests/unit/Client/Action/ActionApiTest.php
@@ -180,6 +180,56 @@ class ActionApiTest extends TestCase {
 		$this->assertEquals( [ 'success ' => 1 ], $result );
 	}
 
+	public function testMultipartRequestWithExtraHeaders(): void {
+		$client = $this->getMockClient();
+		$client->expects( $this->once() )->method( 'request' )->with(
+			'POST',
+			null,
+			[
+				'multipart' => [
+					[ 'name' => 'action', 'contents' => 'upload' ],
+					[ 'name' => 'chunk', 'contents' => 'data', 'headers' => [ 'Content-Disposition' => 'form-data; name="chunk"; filename="foo.jpg"' ] ],
+					[ 'name' => 'format', 'contents' => 'json' ],
+					[ 'name' => 'assert', 'contents' => 'anon' ],
+				],
+				'headers' => [ 'User-Agent' => 'addwiki-mediawiki-client' ],
+			]
+		)->will( $this->returnValue( $this->getMockResponse( [ 'success ' => 1 ] ) ) );
+		$api = new ActionApi( '', null, $client );
+
+		$request = ActionRequest::simplePost( 'upload', [ 'chunk' => 'data' ] )
+			->setMultipartParams( [
+				'chunk' => [ 'headers' => [ 'Content-Disposition' => 'form-data; name="chunk"; filename="foo.jpg"' ] ],
+			] );
+
+		$result = $api->request( $request );
+
+		$this->assertEquals( [ 'success ' => 1 ], $result );
+	}
+
+	public function testMultipartRequestAsync(): void {
+		$client = $this->getMockClient();
+		$client->expects( $this->once() )->method( 'requestAsync' )->with(
+			'POST',
+			null,
+			[
+				'multipart' => [
+					[ 'name' => 'action', 'contents' => 'upload' ],
+					[ 'name' => 'format', 'contents' => 'json' ],
+					[ 'name' => 'assert', 'contents' => 'anon' ],
+				],
+				'headers' => [ 'User-Agent' => 'addwiki-mediawiki-client' ],
+			]
+		)->will( $this->returnValue( new \GuzzleHttp\Promise\FulfilledPromise( $this->getMockResponse( [ 'success ' => 1 ] ) ) ) );
+		$api = new ActionApi( '', null, $client );
+
+		$request = ActionRequest::simplePost( 'upload' )->setMultipart( true );
+
+		$result = $api->requestAsync( $request )->wait();
+
+		$this->assertEquals( [ 'success ' => 1 ], $result );
+	}
+
 	public function provideActionsParamsResults(): array {
 		return [
 			[ [ 'key' => 'value' ], 'logout' ],

--- a/packages/mediawiki-api-base/tests/unit/Client/Action/ActionApiTest.php
+++ b/packages/mediawiki-api-base/tests/unit/Client/Action/ActionApiTest.php
@@ -188,7 +188,11 @@ class ActionApiTest extends TestCase {
 			[
 				'multipart' => [
 					[ 'name' => 'action', 'contents' => 'upload' ],
-					[ 'name' => 'chunk', 'contents' => 'data', 'headers' => [ 'Content-Disposition' => 'form-data; name="chunk"; filename="foo.jpg"' ] ],
+					[
+						'name' => 'chunk',
+						'contents' => 'data',
+						'headers' => [ 'Content-Disposition' => 'form-data; name="chunk"; filename="foo.jpg"' ],
+					],
 					[ 'name' => 'format', 'contents' => 'json' ],
 					[ 'name' => 'assert', 'contents' => 'anon' ],
 				],

--- a/packages/mediawiki-api-base/tests/unit/Client/Rest/RestApiTest.php
+++ b/packages/mediawiki-api-base/tests/unit/Client/Rest/RestApiTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Addwiki\Mediawiki\Api\Tests\Unit\Client\Rest;
+
+use Addwiki\Mediawiki\Api\Client\Action\Tokens;
+use Addwiki\Mediawiki\Api\Client\Rest\RestApi;
+use Addwiki\Mediawiki\Api\Client\Request\StandardRequest;
+use GuzzleHttp\ClientInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+
+class RestApiTest extends TestCase {
+
+	/**
+	 * @return ClientInterface&MockObject
+	 */
+	private function getMockClient() {
+		return $this->createMock( ClientInterface::class );
+	}
+
+	/**
+	 * @return MockObject&ResponseInterface
+	 */
+	private function getMockResponse( $responseValue ) {
+		$mock = $this->createMock( ResponseInterface::class );
+		$mock
+			->method( 'getBody' )
+			->willReturn( \GuzzleHttp\Psr7\Utils::streamFor( json_encode( $responseValue ) ) );
+		return $mock;
+	}
+
+	private function getMockTokens() {
+		return $this->createMock( Tokens::class );
+	}
+
+	public function testGetRequest(): void {
+		$client = $this->getMockClient();
+		$client->expects( $this->once() )
+			->method( 'request' )
+			->with( 'GET', 'http://localhost/rest.php/path', [
+				'query' => [ 'foo' => 'bar', 'assert' => 'anon' ],
+				'headers' => [ 'User-Agent' => 'addwiki-mediawiki-client' ],
+			] )
+			->will( $this->returnValue( $this->getMockResponse( [ 'ok' => true ] ) ) );
+
+		$api = new RestApi( 'http://localhost/rest.php', null, $client, $this->getMockTokens() );
+
+		$request = new class extends StandardRequest {
+			public function getPath(): string { return '/path'; }
+			public function getMethod(): string { return 'GET'; }
+		};
+		$request->setParam( 'foo', 'bar' );
+
+		$result = $api->request( $request );
+		$this->assertEquals( [ 'ok' => true ], $result );
+	}
+
+	public function testMultipartPostRequestWithExtraHeaders(): void {
+		$client = $this->getMockClient();
+		$client->expects( $this->once() )
+			->method( 'request' )
+			->with( 'POST', 'http://localhost/rest.php/upload', [
+				'multipart' => [
+					[ 'name' => 'chunk', 'contents' => 'data', 'headers' => [ 'Content-Disposition' => 'form-data; name="chunk"; filename="foo.jpg"' ] ],
+					[ 'name' => 'assert', 'contents' => 'anon' ],
+				],
+				'headers' => [ 'User-Agent' => 'addwiki-mediawiki-client' ],
+			] )
+			->will( $this->returnValue( $this->getMockResponse( [ 'ok' => true ] ) ) );
+
+		$api = new RestApi( 'http://localhost/rest.php', null, $client, $this->getMockTokens() );
+
+		$request = new class extends StandardRequest {
+			public function getPath(): string { return '/upload'; }
+			public function getMethod(): string { return 'POST'; }
+		};
+		$request->setParam( 'chunk', 'data' );
+		$request->setMultipartParams( [
+			'chunk' => [ 'headers' => [ 'Content-Disposition' => 'form-data; name="chunk"; filename="foo.jpg"' ] ],
+		] );
+
+		$result = $api->request( $request );
+		$this->assertEquals( [ 'ok' => true ], $result );
+	}
+
+}

--- a/packages/mediawiki-api-base/tests/unit/Client/Rest/RestApiTest.php
+++ b/packages/mediawiki-api-base/tests/unit/Client/Rest/RestApiTest.php
@@ -5,9 +5,10 @@ declare( strict_types = 1 );
 namespace Addwiki\Mediawiki\Api\Tests\Unit\Client\Rest;
 
 use Addwiki\Mediawiki\Api\Client\Action\Tokens;
-use Addwiki\Mediawiki\Api\Client\Rest\RestApi;
 use Addwiki\Mediawiki\Api\Client\Request\StandardRequest;
+use Addwiki\Mediawiki\Api\Client\Rest\RestApi;
 use GuzzleHttp\ClientInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 
@@ -48,8 +49,13 @@ class RestApiTest extends TestCase {
 		$api = new RestApi( 'http://localhost/rest.php', null, $client, $this->getMockTokens() );
 
 		$request = new class extends StandardRequest {
-			public function getPath(): string { return '/path'; }
-			public function getMethod(): string { return 'GET'; }
+			public function getPath(): string {
+				return '/path';
+			}
+
+			public function getMethod(): string {
+				return 'GET';
+			}
 		};
 		$request->setParam( 'foo', 'bar' );
 
@@ -63,7 +69,11 @@ class RestApiTest extends TestCase {
 			->method( 'request' )
 			->with( 'POST', 'http://localhost/rest.php/upload', [
 				'multipart' => [
-					[ 'name' => 'chunk', 'contents' => 'data', 'headers' => [ 'Content-Disposition' => 'form-data; name="chunk"; filename="foo.jpg"' ] ],
+					[
+						'name' => 'chunk',
+						'contents' => 'data',
+						'headers' => [ 'Content-Disposition' => 'form-data; name="chunk"; filename="foo.jpg"' ],
+					],
 					[ 'name' => 'assert', 'contents' => 'anon' ],
 				],
 				'headers' => [ 'User-Agent' => 'addwiki-mediawiki-client' ],
@@ -73,8 +83,13 @@ class RestApiTest extends TestCase {
 		$api = new RestApi( 'http://localhost/rest.php', null, $client, $this->getMockTokens() );
 
 		$request = new class extends StandardRequest {
-			public function getPath(): string { return '/upload'; }
-			public function getMethod(): string { return 'POST'; }
+			public function getPath(): string {
+				return '/upload';
+			}
+
+			public function getMethod(): string {
+				return 'POST';
+			}
 		};
 		$request->setParam( 'chunk', 'data' );
 		$request->setMultipartParams( [


### PR DESCRIPTION
I have added unit tests to verify the multipart request handling in the `mediawiki-api-base` package, covering both `ActionApi` and `RestApi`.

Key changes:
- Updated `packages/mediawiki-api-base/tests/unit/Client/Action/ActionApiTest.php` with new test cases:
    - `testMultipartRequestWithExtraHeaders`: Verifies that custom multipart headers (like `Content-Disposition` for chunks) are correctly encoded.
    - `testMultipartRequestAsync`: Verifies multipart handling in asynchronous requests.
- Created `packages/mediawiki-api-base/tests/unit/Client/Rest/RestApiTest.php` to provide coverage for the REST API client, including:
    - Basic GET request verification.
    - Multipart POST request verification with custom headers.

These tests ensure that the multipart encoding logic remains stable and correctly handles the requirements for MediaWiki file uploads.

---
*PR created automatically by Jules for task [10060475199979813272](https://jules.google.com/task/10060475199979813272) started by @addshore*