### PR TITLE
Fix TypeError on non-JSON API response and improve UserAndPassword robustness

### DIFF
--- a/packages/mediawiki-api-base/src/Client/Action/ActionApi.php
+++ b/packages/mediawiki-api-base/src/Client/Action/ActionApi.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace Addwiki\Mediawiki\Api\Client\Action;
 
+use Addwiki\Mediawiki\Api\Client\Action\Exception\UnexpectedResponseException;
 use Addwiki\Mediawiki\Api\Client\Action\Exception\UsageException;
 use Addwiki\Mediawiki\Api\Client\Action\Request\ActionRequest;
 use Addwiki\Mediawiki\Api\Client\Auth\AuthMethod;
@@ -137,6 +138,10 @@ class ActionApi implements Requester, LoggerAwareInterface {
 	 */
 	private function decodeResponse( ResponseInterface $response ) {
 		$resultArray = json_decode( (string)$response->getBody(), true );
+
+		if ( !is_array( $resultArray ) ) {
+			throw new UnexpectedResponseException( $response );
+		}
 
 		$this->logWarnings( $resultArray );
 		$this->throwUsageExceptions( $resultArray );

--- a/packages/mediawiki-api-base/src/Client/Action/Exception/UnexpectedResponseException.php
+++ b/packages/mediawiki-api-base/src/Client/Action/Exception/UnexpectedResponseException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Addwiki\Mediawiki\Api\Client\Action\Exception;
+
+use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
+
+class UnexpectedResponseException extends RuntimeException {
+
+	private ResponseInterface $response;
+
+	public function __construct( ResponseInterface $response, $message = 'Unexpected response from MediaWiki API' ) {
+		$this->response = $response;
+		parent::__construct( $message );
+	}
+
+	public function getResponse(): ResponseInterface {
+		return $this->response;
+	}
+
+}

--- a/packages/mediawiki-api-base/src/Client/Auth/UserAndPassword.php
+++ b/packages/mediawiki-api-base/src/Client/Auth/UserAndPassword.php
@@ -69,21 +69,24 @@ class UserAndPassword implements AuthMethod {
 			return $request;
 		}
 
-		$loginParams = [
-			'lgname' => $this->getUsername(),
-			'lgpassword' => $this->getPassword(),
-		];
+		$loginParams = array_merge(
+			[
+				'lgname' => $this->getUsername(),
+				'lgpassword' => $this->getPassword(),
+			],
+			$this->additionalParamsForPreRequestAuthCall()
+		);
 
 		// First Request
 		$result = $requester->request( ActionRequest::simplePost( 'login', $loginParams ) );
-		if ( $result['login']['result'] == 'NeedToken' ) {
+		if ( isset( $result['login']['result'] ) && $result['login']['result'] == 'NeedToken' ) {
 			$params = array_merge( [ 'lgtoken' => $result['login']['token'] ], $loginParams );
 			// Second Request
 			$result = $requester->request( ActionRequest::simplePost( 'login', $params ) );
 		}
 
 		// Check for success
-		if ( $result['login']['result'] == 'Success' ) {
+		if ( isset( $result['login']['result'] ) && $result['login']['result'] == 'Success' ) {
 			$this->isLoggedIn = true;
 			return $request;
 		}
@@ -103,12 +106,12 @@ class UserAndPassword implements AuthMethod {
 	 * @throws UsageException
 	 */
 	private function throwLoginUsageException( array $result ): void {
-		$loginResult = $result['login']['result'];
+		$loginResult = $result['login']['result'] ?? 'Unknown';
 
 		// TODO use an Auth exception instead? (to make it easier to catch etc?)
 		throw new UsageException(
 			'login-' . $loginResult,
-			array_key_exists( 'reason', $result['login'] )
+			( isset( $result['login'] ) && array_key_exists( 'reason', $result['login'] ) )
 				? $result['login']['reason']
 				: 'No Reason given',
 			$result

--- a/packages/mediawiki-api-base/tests/unit/Client/Auth/Issue205ReproductionTest.php
+++ b/packages/mediawiki-api-base/tests/unit/Client/Auth/Issue205ReproductionTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Addwiki\Mediawiki\Api\Tests\Unit\Client\Auth;
+
+use Addwiki\Mediawiki\Api\Client\Action\ActionApi;
+use Addwiki\Mediawiki\Api\Client\Action\Request\ActionRequest;
+use Addwiki\Mediawiki\Api\Client\Auth\UserAndPassword;
+use GuzzleHttp\ClientInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+
+class Issue205ReproductionTest extends TestCase {
+
+	public function testLoginWithNonJsonResponse(): void {
+		$client = $this->createMock( ClientInterface::class );
+		$mockResponse = $this->createMock( ResponseInterface::class );
+		$mockResponse
+			->method( 'getBody' )
+			->willReturn( \GuzzleHttp\Psr7\Utils::streamFor( '<html>Not JSON</html>' ) );
+
+		$client->method( 'request' )
+			->willReturn( $mockResponse );
+
+		$auth = new UserAndPassword( 'U1', 'P1' );
+		$api = new ActionApi( 'http://example.com/api.php', $auth, $client );
+
+		$this->expectException( \Addwiki\Mediawiki\Api\Client\Action\Exception\UnexpectedResponseException::class );
+		$auth->preRequestAuth( ActionRequest::simpleGet( 'dummy' ), $api );
+	}
+}

--- a/packages/mediawiki-api-base/tests/unit/Client/Auth/UserAndPasswordWithDomainTest.php
+++ b/packages/mediawiki-api-base/tests/unit/Client/Auth/UserAndPasswordWithDomainTest.php
@@ -4,9 +4,13 @@ declare( strict_types = 1 );
 
 namespace Addwiki\Mediawiki\Api\Tests\Unit\Client\Auth;
 
+use Addwiki\Mediawiki\Api\Client\Action\ActionApi;
+use Addwiki\Mediawiki\Api\Client\Action\Request\ActionRequest;
 use Addwiki\Mediawiki\Api\Client\Auth\UserAndPasswordWithDomain;
+use GuzzleHttp\ClientInterface;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * @covers Mediawiki\Api\Client\Auth\UserAndPasswordWithDomain
@@ -65,6 +69,35 @@ class UserAndPasswordWithDomainTest extends TestCase {
 			[ new UserAndPasswordWithDomain( 'usera', 'passa' ), new UserAndPasswordWithDomain( 'DIFF', 'passa' ), false ],
 			[ new UserAndPasswordWithDomain( 'usera', 'passa' ), new UserAndPasswordWithDomain( 'usera', 'DIFF' ), false ],
 		];
+	}
+
+	/**
+	 * @return MockObject&ResponseInterface
+	 */
+	private function getMockResponse( $responseValue ) {
+		$mock = $this->createMock( ResponseInterface::class );
+		$mock
+			->method( 'getBody' )
+			->willReturn( \GuzzleHttp\Psr7\Utils::streamFor( json_encode( $responseValue ) ) );
+		return $mock;
+	}
+
+	public function testDomainIsSent(): void {
+		$client = $this->createMock( ClientInterface::class );
+		$client->expects( $this->once() )
+			->method( 'request' )
+			->with(
+				'POST',
+				$this->anything(),
+				$this->callback( static function ( $options ) {
+					return isset( $options['form_params']['lgdomain'] ) && $options['form_params']['lgdomain'] === 'mydomain';
+				} )
+			)
+			->willReturn( $this->getMockResponse( [ 'login' => [ 'result' => 'Success' ] ] ) );
+
+		$auth = new UserAndPasswordWithDomain( 'U1', 'P1', 'mydomain' );
+		$api = new ActionApi( '', $auth, $client );
+		$auth->preRequestAuth( ActionRequest::simpleGet( 'dummy' ), $api );
 	}
 
 }


### PR DESCRIPTION
This PR addresses issue #205 where a non-JSON response from the MediaWiki API (e.g., an HTML redirect page) causes a `TypeError` in the authentication logic.

Key changes:
1.  **`ActionApi`**: `decodeResponse` now checks if the JSON-decoded result is an array. If not, it throws a new `UnexpectedResponseException`, providing access to the original PSR-7 response for debugging.
2.  **`UserAndPassword`**:
    *   Updated `preRequestAuth` to use `isset()` and null-coalescing operators when accessing API results, preventing `TypeError: Argument #1 ($result) must be of type array, null given`.
    *   Fixed a bug where `additionalParamsForPreRequestAuthCall()` (used by `UserAndPasswordWithDomain`) was not actually being called, meaning `lgdomain` was never sent.
3.  **Tests**:
    *   Added `Issue205ReproductionTest` to verify that a non-JSON response triggers the new `UnexpectedResponseException` instead of a `TypeError`.
    *   Added a test case to `UserAndPasswordWithDomainTest` to ensure that the domain parameter is correctly included in the login request.
    *   Preserved all existing unit tests.

---
*PR created automatically by Jules for task [12456563815102001380](https://jules.google.com/task/12456563815102001380) started by @addshore*