### PR TITLE
Fix User-Agent mismatches in unit tests

### DIFF
--- a/packages/mediawiki-api-base/tests/unit/Client/Action/ActionApiTest.php
+++ b/packages/mediawiki-api-base/tests/unit/Client/Action/ActionApiTest.php
@@ -52,14 +52,18 @@ class ActionApiTest extends TestCase {
 		return $mock;
 	}
 
+	private function getUserAgent(): string {
+		$version = \Composer\InstalledVersions::getPrettyVersion( 'addwiki/addwiki' );
+		return "addwiki/addwiki-$version mediawiki-api-base/$version";
+	}
+
 	/**
 	 * @return array <int|string mixed[]>
 	 */
 	private function getExpectedRequestOpts( $params, $paramsLocation ): array {
-		$version = \Composer\InstalledVersions::getPrettyVersion( 'addwiki/addwiki' );
 		return [
 			$paramsLocation => array_merge( $params, [ 'format' => 'json', 'assert' => 'anon' ] ),
-			'headers' => [ 'User-Agent' => "addwiki/addwiki-$version mediawiki-api-base/$version" ],
+			'headers' => [ 'User-Agent' => $this->getUserAgent() ],
 		];
 	}
 
@@ -154,7 +158,6 @@ class ActionApiTest extends TestCase {
 	}
 
 	public function testPostActionWithFileReturnsResult(): void {
-		$version = \Composer\InstalledVersions::getPrettyVersion( 'addwiki/addwiki' );
 		$dummyFile = $this->getNullFilePointer();
 		$params = [
 			'filename' => 'foo.jpg',
@@ -172,7 +175,7 @@ class ActionApiTest extends TestCase {
 						[ 'name' => 'format', 'contents' => 'json' ],
 						[ 'name' => 'assert', 'contents' => 'anon' ],
 					],
-					'headers' => [ 'User-Agent' => "addwiki/addwiki-$version mediawiki-api-base/$version" ],
+					'headers' => [ 'User-Agent' => $this->getUserAgent() ],
 				]
 			)->will( $this->returnValue( $this->getMockResponse( [ 'success ' => 1 ] ) ) );
 		$api = new ActionApi( '', null, $client );
@@ -198,7 +201,7 @@ class ActionApiTest extends TestCase {
 					[ 'name' => 'format', 'contents' => 'json' ],
 					[ 'name' => 'assert', 'contents' => 'anon' ],
 				],
-				'headers' => [ 'User-Agent' => 'addwiki-mediawiki-client' ],
+				'headers' => [ 'User-Agent' => $this->getUserAgent() ],
 			]
 		)->will( $this->returnValue( $this->getMockResponse( [ 'success ' => 1 ] ) ) );
 		$api = new ActionApi( '', null, $client );
@@ -224,7 +227,7 @@ class ActionApiTest extends TestCase {
 					[ 'name' => 'format', 'contents' => 'json' ],
 					[ 'name' => 'assert', 'contents' => 'anon' ],
 				],
-				'headers' => [ 'User-Agent' => 'addwiki-mediawiki-client' ],
+				'headers' => [ 'User-Agent' => $this->getUserAgent() ],
 			]
 		)->will( $this->returnValue( new \GuzzleHttp\Promise\FulfilledPromise( $this->getMockResponse( [ 'success ' => 1 ] ) ) ) );
 		$api = new ActionApi( '', null, $client );

--- a/packages/mediawiki-api-base/tests/unit/Client/Rest/RestApiTest.php
+++ b/packages/mediawiki-api-base/tests/unit/Client/Rest/RestApiTest.php
@@ -36,13 +36,18 @@ class RestApiTest extends TestCase {
 		return $this->createMock( Tokens::class );
 	}
 
+	private function getUserAgent(): string {
+		$version = \Composer\InstalledVersions::getPrettyVersion( 'addwiki/addwiki' );
+		return "addwiki/addwiki-$version mediawiki-api-base/$version";
+	}
+
 	public function testGetRequest(): void {
 		$client = $this->getMockClient();
 		$client->expects( $this->once() )
 			->method( 'request' )
 			->with( 'GET', 'http://localhost/rest.php/path', [
 				'query' => [ 'foo' => 'bar', 'assert' => 'anon' ],
-				'headers' => [ 'User-Agent' => 'addwiki-mediawiki-client' ],
+				'headers' => [ 'User-Agent' => $this->getUserAgent() ],
 			] )
 			->will( $this->returnValue( $this->getMockResponse( [ 'ok' => true ] ) ) );
 
@@ -76,7 +81,7 @@ class RestApiTest extends TestCase {
 					],
 					[ 'name' => 'assert', 'contents' => 'anon' ],
 				],
-				'headers' => [ 'User-Agent' => 'addwiki-mediawiki-client' ],
+				'headers' => [ 'User-Agent' => $this->getUserAgent() ],
 			] )
 			->will( $this->returnValue( $this->getMockResponse( [ 'ok' => true ] ) ) );
 


### PR DESCRIPTION
Fixed unit test failures in ActionApiTest and RestApiTest caused by User-Agent header mismatches. Updated hardcoded "addwiki-mediawiki-client" expectations to dynamically generated versioned strings using `Composer\InstalledVersions::getPrettyVersion`. Verified all unit tests pass.

---
*PR created automatically by Jules for task [4641955227731318632](https://jules.google.com/task/4641955227731318632) started by @addshore*